### PR TITLE
Add drop shadow presets to theme.json

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-siteworks-theme ===
 Requires at least: 5.9
-Tested up to: 6.4.3
+Tested up to: 6.5
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -22,15 +22,17 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
-=1.9.7 =
+= 1.9.8 =
+* Add drop shadow presets to theme.json in black, u3a dark blue and u3a orange
+= 1.9.7 =
 * Simplify code in Functions.php and rename references to u3a test to u3a_theme
-=1.9.6 =
+= 1.9.6 =
 * Remove test patterns from Functions.php
-=1.9.5 =
+= 1.9.5 =
 * Add button colours to the alternate styles
-=1.9.4 =
+= 1.9.4 =
 * Revert site logo block change to use heading block to prevent copyright issues
-=1.9.3 =
+= 1.9.3 =
 * Add spacer block to single.html template to prevent large left aligned images overlapping footer
 * And restore search box min width to style.css . Also add comments,
 = 1.9.2 =

--- a/theme.json
+++ b/theme.json
@@ -139,6 +139,74 @@
       "contentSize": "840px",
       "wideSize": "1100px"
     },
+    "shadow": {
+      "presets": [
+        {
+          "name": "shadow1",
+          "shadow": "rgba(0, 0, 0, 0.16) 0px 3px 6px, rgba(0, 0, 0, 0.23) 0px 3px 6px",
+          "slug": "shadow1"
+        },
+        {
+          "name": "shadow2",
+          "shadow": "rgba(0, 0, 0, 0.19) 0px 10px 20px, rgba(0, 0, 0, 0.23) 0px 6px 6px",
+          "slug": "shadow2"
+        },
+        {
+          "name": "shadow3",
+          "shadow": "rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px",
+          "slug": "shadow3"
+        },
+        {
+          "name": "shadow4",
+          "shadow": "rgba(0, 0, 0, 0.3) 0px 19px 38px, rgba(0, 0, 0, 0.22) 0px 15px 12px",
+          "slug": "shadow4"
+        },
+
+        {
+          "name": "shadow5",
+          "shadow": "rgba(0, 90, 185, 0.16) 0px 3px 6px, rgba(0, 90, 185, 0.23) 0px 3px 6px",
+          "slug": "shadow5"
+        },
+        {
+          "name": "shadow6",
+          "shadow": "rgba(0, 90, 185, 0.19) 0px 10px 20px, rgba(0, 90, 185, 0.23) 0px 6px 6px",
+          "slug": "shadow6"
+        },
+        {
+          "name": "shadow7",
+          "shadow": "rgba(0, 90, 185, 0.25) 0px 14px 28px, rgba(0, 90, 185, 0.22) 0px 10px 10px",
+          "slug": "shadow7"
+        },
+        {
+          "name": "shadow8",
+          "shadow": "rgba(0, 90, 185, 0.3) 0px 19px 38px, rgba(0, 90, 185, 0.22) 0px 15px 12px",
+          "slug": "shadow8"
+        },
+
+        {
+          "name": "shadow9",
+          "shadow": "rgb(255, 170, 50, 0.16) 0px 3px 6px, rgb(255, 170, 50, 0.23) 0px 3px 6px",
+          "slug": "shadow9"
+        },
+        {
+          "name": "shadow10",
+          "shadow": "rgb(255, 170, 50, 0.19) 0px 10px 20px, rgb(255, 170, 50, 0.23) 0px 6px 6px",
+          "slug": "shadow10"
+        },
+        {
+          "name": "shadow11",
+          "shadow": "rgb(255, 170, 50, 0.25) 0px 14px 28px, rgb(255, 170, 50, 0.22) 0px 10px 10px",
+          "slug": "shadow11"
+        },
+        {
+          "name": "shadow12",
+          "shadow": "rgb(255, 170, 50, 0.3) 0px 19px 38px, rgb(255, 170, 50, 0.22) 0px 15px 12px",
+          "slug": "shadow12"
+        }
+
+
+      ]
+    },
     "spacing": {
       "units": [
         "%",


### PR DESCRIPTION
This adds the "shadow" section to "settings" to provide additional preset drop shadow styles in u3a colours.
Also sets "Tested up to: 6.5"